### PR TITLE
大佬，发现您的项目引入了org.apache.hadoop:hadoop-common@2.7.5组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.geek</groupId>
@@ -18,7 +16,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.5</version>
+            <version>2.8.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Hadoop 路径遍历漏洞
缺陷组件：org.apache.hadoop:hadoop-common@2.7.5
漏洞编号：CVE-2018-8009
漏洞描述：Apache Hadoop是美国阿帕奇（Apache）软件基金会的一套开源的分布式系统基础架构，它能够对大量数据进行分布式处理，并具有高可靠性、高扩展性、高容错性等特点。
Apache Hadoop中存在任意文件写入漏洞。攻击者可借助特制的zip文件利用该漏洞执行任意代码。以下版本受到影响：Apache Hadoop 3.1.0版本，3.0.0-alpha版本至3.0.2版本，2.9.0版本至2.9.1版本，2.8.0版本至2.8.4版本，2.0.0-alpha版本至2.7.6版本，0.23.0版本至0.23.11版本。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2018-24150
影响范围：[2.7.0, 2.7.7)
最小修复版本：2.8.3
缺陷组件引入路径：org.geek:geek@1.0-HOMEWORK->org.apache.hadoop:hadoop-common@2.7.5
```
另外我运行这个项目时，IDE的安全插件提示还有30个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p10fdd